### PR TITLE
Support LazyFrames

### DIFF
--- a/polars_random/__init__.py
+++ b/polars_random/__init__.py
@@ -48,6 +48,7 @@ def _check_probability(prob: float) -> None:
 
 
 @pl.api.register_dataframe_namespace("random")
+@pl.api.register_lazyframe_namespace("random")
 class Random:
     """
     Namespace for generating new columns in the dataframe containing statistical distributions.

--- a/tests/test_polars_random.py
+++ b/tests/test_polars_random.py
@@ -12,19 +12,31 @@ import polars_random  # noqa
         ("binomial", dict(n=10, p=0.5), 5.0),
     ],
 )
-def test_all(func_name: str, params: dict[str, float], target: float) -> None:
+@pytest.mark.parametrize(
+    ("lazy", "streaming"),
+    [
+        (False, False),
+    ],
+)
+def test_all(
+    lazy: bool, streaming: bool, func_name: str, params: dict[str, float], target: float
+) -> None:
     # Initialize the dataframe
     df: pl.DataFrame | pl.LazyFrame = pl.DataFrame(
         {
             "a": range(1_000_000),
         }
     )
+    if lazy:
+        df = df.lazy()
 
     # Add the random column
     df = getattr(df.random, func_name)(**params, name="rand")  # type: ignore
 
     # Calculate the mean
     df_mean = df.select(pl.col("rand").mean())
+    if lazy:
+        df_mean = df_mean.collect(streaming=streaming)
     mean = df_mean.item()
 
     assert abs(mean - target) < 0.01

--- a/tests/test_polars_random.py
+++ b/tests/test_polars_random.py
@@ -16,6 +16,8 @@ import polars_random  # noqa
     ("lazy", "streaming"),
     [
         (False, False),
+        (True, False),
+        (True, True),
     ],
 )
 def test_all(

--- a/tests/test_polars_random.py
+++ b/tests/test_polars_random.py
@@ -1,30 +1,30 @@
 import polars as pl
+import pytest
 
 import polars_random  # noqa
 
 
-def test_normal():
-    df = pl.DataFrame(
+@pytest.mark.parametrize(
+    ("func_name", "params", "target"),
+    [
+        ("normal", dict(mean=0.0, std=1.0), 0.0),
+        ("rand", dict(low=0.0, high=1.0), 0.5),
+        ("binomial", dict(n=10, p=0.5), 5.0),
+    ],
+)
+def test_all(func_name: str, params: dict[str, float], target: float) -> None:
+    # Initialize the dataframe
+    df: pl.DataFrame | pl.LazyFrame = pl.DataFrame(
         {
             "a": range(1_000_000),
         }
-    ).random.normal(mean=0.0, std=1.0)  # type: ignore
-    assert abs(df.select(pl.col("normal").mean()).item() - 0.0) < 0.01
+    )
 
+    # Add the random column
+    df = getattr(df.random, func_name)(**params, name="rand")  # type: ignore
 
-def test_uniform():
-    df = pl.DataFrame(
-        {
-            "a": range(1_000_000),
-        }
-    ).random.rand(low=0.0, high=1.0)  # type: ignore
-    assert abs(df.select(pl.col("rand").mean()).item() - 0.5) < 0.01
+    # Calculate the mean
+    df_mean = df.select(pl.col("rand").mean())
+    mean = df_mean.item()
 
-
-def test_binomial():
-    df = pl.DataFrame(
-        {
-            "a": range(1_000_000),
-        }
-    ).random.binomial(n=10, p=0.5)  # type: ignore
-    assert abs(df.select(pl.col("binomial").mean()).item() - 5) < 0.01
+    assert abs(mean - target) < 0.01


### PR DESCRIPTION
Allow calling the random functions also on LazyFrames. There was no need to add any functionality since the existing implementation also works on LazyFrames. This PR adds a call to `@pl.api.register_lazyframe_namespace` and adds corresponding tests on LazyFrames.