### PR TITLE
[docs] fix README typos and incorrect examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ uv add polars-random
 ```sh
 poetry add polars-random
 ```
+
 ```sh
 pip install polars-random
 ```
-
 
 ## Usage
 
@@ -51,14 +51,15 @@ If we want to generate a new uniform column called `rand` based on some paramete
 )
 ```
 
-We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=1.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
+We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=0.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
 ```python
 (
     df
     .random.rand(
-        seed=42, 
+        seed=42,
         name="rand_seed",
     )
+)
 ```
 
 If we want custom parameters, we can use `polars expressions`. Let's say we have two columns called `custom_low` and `custom_high`. For generating a new column, we can use either the expression `pl.col("custom_low")` or a python string `"custom_low"`:
@@ -82,6 +83,8 @@ If we want custom parameters, we can use `polars expressions`. Let's say we have
 
 ### Uniform distribution
 
+`random.uniform` is provided as an alias for `random.rand`.
+
 ```python
 import polars as pl
 import polars_random
@@ -98,8 +101,8 @@ random_series = (
         name="rand_expr",
     )
     .random.rand(
-        mean="custom_low",
-        std="custom_high",
+        low="custom_low",
+        high="custom_high",
         name="rand_str",
     )
 )

--- a/README.md
+++ b/README.md
@@ -1,16 +1,44 @@
 # polars-random
 
-Polars plugin for generating random distributions.
+[![PyPI version](https://img.shields.io/pypi/v/polars-random.svg)](https://pypi.org/project/polars-random/)
+[![Python versions](https://img.shields.io/pypi/pyversions/polars-random.svg)](https://pypi.org/project/polars-random/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/diegoglozano/polars-random/blob/main/LICENSE)
+[![CI](https://github.com/diegoglozano/polars-random/actions/workflows/testing.yml/badge.svg)](https://github.com/diegoglozano/polars-random/actions/workflows/testing.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://diegoglozano.github.io/polars-random/)
 
-## Description
+**Generate random numbers and statistical distributions natively in [Polars](https://pola.rs/) DataFrames** — a NumPy-style random API exposed as first-class Polars expressions, with reproducible seeds and per-row parameters.
 
-`polars-random` is a Rust plugin for the Polars DataFrame library that provides functionality to generate random numbers through a new dataframe namespace called "random". It supports generating random numbers from various distributions such as uniform, normal, and binomial.
+`polars-random` is a Rust plugin that registers a `.random` namespace on `pl.DataFrame`. Use it to add columns of uniform, normal, or binomial draws — with parameters that can be Python literals, column names, or arbitrary Polars expressions.
 
-You can set seeds, and pass the parameters as polars expressions or column names (as strings).
+```python
+import polars as pl
+import polars_random  # registers df.random
+
+df = pl.DataFrame({"id": range(5)})
+
+df.random.normal(mean=0.0, std=1.0, seed=42, name="noise")
+# shape: (5, 2)
+# ┌─────┬───────────┐
+# │ id  ┆ noise     │
+# │ --- ┆ ---       │
+# │ i64 ┆ f64       │
+# ╞═════╪═══════════╡
+# │ 0   ┆  0.49671… │
+# │ 1   ┆ -0.13826… │
+# │ 2   ┆  0.64769… │
+# │ 3   ┆  1.52303… │
+# │ 4   ┆ -0.23415… │
+# └─────┴───────────┘
+```
+
+## Why polars-random?
+
+- **Polars-native** — outputs are regular Polars columns, composable with the rest of your pipeline (no NumPy round-trips).
+- **Per-row parameters** — `mean`, `std`, `low`, `high`, `n`, `p` can come from other columns, so each row can be drawn from a different distribution.
+- **Reproducible** — pass `seed=...` for deterministic draws.
+- **Fast** — implemented in Rust on top of `rand` / `rand_distr`.
 
 ## Installation
-
-To use `polars-random`, install it using your favourite tool:
 
 ```sh
 uv add polars-random
@@ -24,136 +52,122 @@ poetry add polars-random
 pip install polars-random
 ```
 
-## Usage
+## How it works (mental model)
 
-For every available distribution, parameters can be passed as `polars expressions` or native python objects (`int`, `float`, `string`...).
-
-Here are some examples of how to use the `polars-random` plugin for generating uniform distributions:
+Every distribution follows the same shape:
 
 ```python
-import polars as pl
-# This will automatically register .random
-# in pl.DataFrame namespace
-import polars_random
-
-df: pl.DataFrame = ...
+df.random.<distribution>(<params>, seed=None, name=None)
 ```
 
-If we want to generate a new uniform column called `rand` based on some parameters:
-```python
-(
-    df
-    .random.rand(
-        low=1_000.,
-        high=2_000.,
-        name="rand",
-    )
-)
-```
+- `<params>` are the distribution's parameters (e.g. `low`/`high`, `mean`/`std`, `n`/`p`).
+- Each parameter accepts **a Python literal**, **a column name as a string**, or **a Polars expression** (`pl.col(...)`, arithmetic, etc.). Within a single call, all distribution parameters must be the same kind — either all literals or all expressions/column-names (no mixing).
+- `seed` makes the draw reproducible. Omit it for entropy-based randomness.
+- `name` is the new column's name. Defaults to the distribution name (`"rand"`, `"normal"`, `"binomial"`).
+- The result is a new `pl.DataFrame` with the column appended. Calls chain.
 
-We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=0.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
-```python
-(
-    df
-    .random.rand(
-        seed=42,
-        name="rand_seed",
-    )
-)
-```
+## Coming from NumPy?
 
-If we want custom parameters, we can use `polars expressions`. Let's say we have two columns called `custom_low` and `custom_high`. For generating a new column, we can use either the expression `pl.col("custom_low")` or a python string `"custom_low"`:
-```python
-(
-    df
-    .random.rand(
-        low=pl.col("custom_low"),
-        high=pl.col("custom_high"),
-        name="rand_expr",
-    )
-    .random.rand(
-        low="custom_low",
-        high="custom_high",
-        name="rand_str",
-    )
-)
-```
+| NumPy                                    | polars-random                                            |
+| ---------------------------------------- | -------------------------------------------------------- |
+| `np.random.uniform(low, high, size=n)`   | `df.random.rand(low=low, high=high)`                     |
+| `np.random.normal(mean, std, size=n)`    | `df.random.normal(mean=mean, std=std)`                   |
+| `np.random.binomial(n, p, size=size)`    | `df.random.binomial(n=n, p=p)`                           |
+| `np.random.seed(42)` (global)            | `seed=42` per call                                       |
+| Different params per row (loop / vectorize manually) | Pass a column name or `pl.col(...)` as the parameter |
+
+The output length always matches the DataFrame's height — no `size=` argument needed.
 
 ## Distributions
 
-### Uniform distribution
+### `df.random.rand` (uniform) · also aliased as `df.random.uniform`
 
-`random.uniform` is provided as an alias for `random.rand`.
-
-```python
-import polars as pl
-import polars_random
-
-df: pl.DataFrame = ...
-
-random_series = (
-    df
-    .random.rand(low=1_000., high=2_000., name="rand")
-    .random.rand(seed=42, name="rand_seed")
-    .random.rand(
-        low=pl.col("custom_low"),
-        high=pl.col("custom_high"),
-        name="rand_expr",
-    )
-    .random.rand(
-        low="custom_low",
-        high="custom_high",
-        name="rand_str",
-    )
-)
-```
-
-### Normal Distribution
+| Parameter | Type                                    | Default | Description                  |
+| --------- | --------------------------------------- | ------- | ---------------------------- |
+| `low`     | `float`, `str`, `pl.Expr`, or `None`    | `0.0`   | Lower bound (inclusive).     |
+| `high`    | `float`, `str`, `pl.Expr`, or `None`    | `1.0`   | Upper bound (exclusive).     |
+| `seed`    | `int` or `None`                         | `None`  | Reproducible draws.          |
+| `name`    | `str` or `None`                         | `"rand"`| Output column name.          |
 
 ```python
 import polars as pl
 import polars_random
 
-df: pl.DataFrame = ...
+df = pl.DataFrame({
+    "custom_low":  [0.0, 10.0, 100.0],
+    "custom_high": [1.0, 20.0, 200.0],
+})
 
-random_series = (
+(
     df
-    .random.normal(mean=3., std=2., name="normal")
-    .random.normal(seed=42, name="normal_seed")
-    .random.normal(
-        mean=pl.col("custom_mean"),
-        std=pl.col("custom_std"),
-        name="normal_expr",
-    )
-    .random.normal(
-        mean="custom_mean",
-        std="custom_std",
-        name="normal_str",
-    )
+    # Scalar parameters
+    .random.rand(low=1_000., high=2_000., seed=42, name="rand_scalar")
+    # Default range [0, 1)
+    .random.rand(seed=42, name="rand_default")
+    # Per-row parameters via expression
+    .random.rand(low=pl.col("custom_low"), high=pl.col("custom_high"), seed=42, name="rand_expr")
+    # Per-row parameters via column name
+    .random.rand(low="custom_low", high="custom_high", seed=42, name="rand_str")
 )
 ```
 
-### Binomial Distribution
+### `df.random.normal`
+
+| Parameter | Type                                    | Default    | Description                          |
+| --------- | --------------------------------------- | ---------- | ------------------------------------ |
+| `mean`    | `float`, `str`, `pl.Expr`, or `None`    | `0.0`      | Mean of the normal distribution.     |
+| `std`     | `float`, `str`, `pl.Expr`, or `None`    | `1.0`      | Standard deviation (must be `> 0`).  |
+| `seed`    | `int` or `None`                         | `None`     | Reproducible draws.                  |
+| `name`    | `str` or `None`                         | `"normal"` | Output column name.                  |
 
 ```python
 import polars as pl
 import polars_random
 
-df: pl.DataFrame = ...
+df = pl.DataFrame({
+    "custom_mean": [0.0, 5.0, -3.0],
+    "custom_std":  [1.0, 2.0, 0.5],
+})
 
-random_series = (
+(
     df
-    # Mandatory parameters n and p
-    .random.binomial(n=100, p=.5, seed=42, name="binomial")
-    .random.binomial(
-        n=pl.col("custom_n"),
-        p=pl.col("custom_p"),
-        name="binomial_expr",
-    )
-    .random.binomial(
-        n="n",
-        p="p",
-        name="binomial_str",
-    )
+    .random.normal(mean=3., std=2., seed=42, name="normal_scalar")
+    .random.normal(seed=42, name="normal_default")  # mean=0, std=1
+    .random.normal(mean=pl.col("custom_mean"), std=pl.col("custom_std"), seed=42, name="normal_expr")
+    .random.normal(mean="custom_mean", std="custom_std", seed=42, name="normal_str")
 )
 ```
+
+### `df.random.binomial`
+
+| Parameter | Type                          | Default      | Description                                       |
+| --------- | ----------------------------- | ------------ | ------------------------------------------------- |
+| `n`       | `int`, `str`, or `pl.Expr`    | *(required)* | Number of trials.                                 |
+| `p`       | `float`, `str`, or `pl.Expr`  | *(required)* | Probability of success on each trial (`0 ≤ p ≤ 1`). |
+| `seed`    | `int` or `None`               | `None`       | Reproducible draws.                               |
+| `name`    | `str` or `None`               | `"binomial"` | Output column name.                               |
+
+```python
+import polars as pl
+import polars_random
+
+df = pl.DataFrame({
+    "n": [10, 50, 100],
+    "p": [0.1, 0.5, 0.9],
+})
+
+(
+    df
+    .random.binomial(n=100, p=.5, seed=42, name="binomial_scalar")
+    .random.binomial(n=pl.col("n"), p=pl.col("p"), seed=42, name="binomial_expr")
+    .random.binomial(n="n", p="p", seed=42, name="binomial_str")
+)
+```
+
+## Documentation
+
+Full API reference: <https://diegoglozano.github.io/polars-random/>
+
+## License
+
+[MIT](LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,10 @@ uv add polars-random
 ```sh
 poetry add polars-random
 ```
+
 ```sh
 pip install polars-random
 ```
-
 
 ## Usage
 
@@ -51,14 +51,15 @@ If we want to generate a new uniform column called `rand` based on some paramete
 )
 ```
 
-We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=1.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
+We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=0.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
 ```python
 (
     df
     .random.rand(
-        seed=42, 
+        seed=42,
         name="rand_seed",
     )
+)
 ```
 
 If we want custom parameters, we can use `polars expressions`. Let's say we have two columns called `custom_low` and `custom_high`. For generating a new column, we can use either the expression `pl.col("custom_low")` or a python string `"custom_low"`:
@@ -82,6 +83,8 @@ If we want custom parameters, we can use `polars expressions`. Let's say we have
 
 ### Uniform distribution
 
+`random.uniform` is provided as an alias for `random.rand`.
+
 ```python
 import polars as pl
 import polars_random
@@ -98,8 +101,8 @@ random_series = (
         name="rand_expr",
     )
     .random.rand(
-        mean="custom_low",
-        std="custom_high",
+        low="custom_low",
+        high="custom_high",
         name="rand_str",
     )
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,43 @@
-# polars-random docs
+# polars-random
 
-Polars plugin for generating random distributions.
+[![PyPI version](https://img.shields.io/pypi/v/polars-random.svg)](https://pypi.org/project/polars-random/)
+[![Python versions](https://img.shields.io/pypi/pyversions/polars-random.svg)](https://pypi.org/project/polars-random/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/diegoglozano/polars-random/blob/main/LICENSE)
+[![CI](https://github.com/diegoglozano/polars-random/actions/workflows/testing.yml/badge.svg)](https://github.com/diegoglozano/polars-random/actions/workflows/testing.yml)
 
-## Description
+**Generate random numbers and statistical distributions natively in [Polars](https://pola.rs/) DataFrames** — a NumPy-style random API exposed as first-class Polars expressions, with reproducible seeds and per-row parameters.
 
-`polars-random` is a Rust plugin for the Polars DataFrame library that provides functionality to generate random numbers through a new dataframe namespace called "random". It supports generating random numbers from various distributions such as uniform, normal, and binomial.
+`polars-random` is a Rust plugin that registers a `.random` namespace on `pl.DataFrame`. Use it to add columns of uniform, normal, or binomial draws — with parameters that can be Python literals, column names, or arbitrary Polars expressions.
 
-You can set seeds, and pass the parameters as polars expressions or column names (as strings).
+```python
+import polars as pl
+import polars_random  # registers df.random
+
+df = pl.DataFrame({"id": range(5)})
+
+df.random.normal(mean=0.0, std=1.0, seed=42, name="noise")
+# shape: (5, 2)
+# ┌─────┬───────────┐
+# │ id  ┆ noise     │
+# │ --- ┆ ---       │
+# │ i64 ┆ f64       │
+# ╞═════╪═══════════╡
+# │ 0   ┆  0.49671… │
+# │ 1   ┆ -0.13826… │
+# │ 2   ┆  0.64769… │
+# │ 3   ┆  1.52303… │
+# │ 4   ┆ -0.23415… │
+# └─────┴───────────┘
+```
+
+## Why polars-random?
+
+- **Polars-native** — outputs are regular Polars columns, composable with the rest of your pipeline (no NumPy round-trips).
+- **Per-row parameters** — `mean`, `std`, `low`, `high`, `n`, `p` can come from other columns, so each row can be drawn from a different distribution.
+- **Reproducible** — pass `seed=...` for deterministic draws.
+- **Fast** — implemented in Rust on top of `rand` / `rand_distr`.
 
 ## Installation
-
-To use `polars-random`, install it using your favourite tool:
 
 ```sh
 uv add polars-random
@@ -24,136 +51,118 @@ poetry add polars-random
 pip install polars-random
 ```
 
-## Usage
+## How it works (mental model)
 
-For every available distribution, parameters can be passed as `polars expressions` or native python objects (`int`, `float`, `string`...).
-
-Here are some examples of how to use the `polars-random` plugin for generating uniform distributions:
+Every distribution follows the same shape:
 
 ```python
-import polars as pl
-# This will automatically register .random
-# in pl.DataFrame namespace
-import polars_random
-
-df: pl.DataFrame = ...
+df.random.<distribution>(<params>, seed=None, name=None)
 ```
 
-If we want to generate a new uniform column called `rand` based on some parameters:
-```python
-(
-    df
-    .random.rand(
-        low=1_000.,
-        high=2_000.,
-        name="rand",
-    )
-)
-```
+- `<params>` are the distribution's parameters (e.g. `low`/`high`, `mean`/`std`, `n`/`p`).
+- Each parameter accepts **a Python literal**, **a column name as a string**, or **a Polars expression** (`pl.col(...)`, arithmetic, etc.). Within a single call, all distribution parameters must be the same kind — either all literals or all expressions/column-names (no mixing).
+- `seed` makes the draw reproducible. Omit it for entropy-based randomness.
+- `name` is the new column's name. Defaults to the distribution name (`"rand"`, `"normal"`, `"binomial"`).
+- The result is a new `pl.DataFrame` with the column appended. Calls chain.
 
-We can also add a `seed` and make the generation reproducible. In the following case, we are using default parameters (`low=0.` and `high=1.`) and generating a uniform distribution called `rand_seed`:
-```python
-(
-    df
-    .random.rand(
-        seed=42,
-        name="rand_seed",
-    )
-)
-```
+## Coming from NumPy?
 
-If we want custom parameters, we can use `polars expressions`. Let's say we have two columns called `custom_low` and `custom_high`. For generating a new column, we can use either the expression `pl.col("custom_low")` or a python string `"custom_low"`:
-```python
-(
-    df
-    .random.rand(
-        low=pl.col("custom_low"),
-        high=pl.col("custom_high"),
-        name="rand_expr",
-    )
-    .random.rand(
-        low="custom_low",
-        high="custom_high",
-        name="rand_str",
-    )
-)
-```
+| NumPy                                    | polars-random                                            |
+| ---------------------------------------- | -------------------------------------------------------- |
+| `np.random.uniform(low, high, size=n)`   | `df.random.rand(low=low, high=high)`                     |
+| `np.random.normal(mean, std, size=n)`    | `df.random.normal(mean=mean, std=std)`                   |
+| `np.random.binomial(n, p, size=size)`    | `df.random.binomial(n=n, p=p)`                           |
+| `np.random.seed(42)` (global)            | `seed=42` per call                                       |
+| Different params per row (loop / vectorize manually) | Pass a column name or `pl.col(...)` as the parameter |
+
+The output length always matches the DataFrame's height — no `size=` argument needed.
 
 ## Distributions
 
-### Uniform distribution
+### `df.random.rand` (uniform) · also aliased as `df.random.uniform`
 
-`random.uniform` is provided as an alias for `random.rand`.
-
-```python
-import polars as pl
-import polars_random
-
-df: pl.DataFrame = ...
-
-random_series = (
-    df
-    .random.rand(low=1_000., high=2_000., name="rand")
-    .random.rand(seed=42, name="rand_seed")
-    .random.rand(
-        low=pl.col("custom_low"),
-        high=pl.col("custom_high"),
-        name="rand_expr",
-    )
-    .random.rand(
-        low="custom_low",
-        high="custom_high",
-        name="rand_str",
-    )
-)
-```
-
-### Normal Distribution
+| Parameter | Type                                    | Default  | Description              |
+| --------- | --------------------------------------- | -------- | ------------------------ |
+| `low`     | `float`, `str`, `pl.Expr`, or `None`    | `0.0`    | Lower bound (inclusive). |
+| `high`    | `float`, `str`, `pl.Expr`, or `None`    | `1.0`    | Upper bound (exclusive). |
+| `seed`    | `int` or `None`                         | `None`   | Reproducible draws.      |
+| `name`    | `str` or `None`                         | `"rand"` | Output column name.      |
 
 ```python
 import polars as pl
 import polars_random
 
-df: pl.DataFrame = ...
+df = pl.DataFrame({
+    "custom_low":  [0.0, 10.0, 100.0],
+    "custom_high": [1.0, 20.0, 200.0],
+})
 
-random_series = (
+(
     df
-    .random.normal(mean=3., std=2., name="normal")
-    .random.normal(seed=42, name="normal_seed")
-    .random.normal(
-        mean=pl.col("custom_mean"),
-        std=pl.col("custom_std"),
-        name="normal_expr",
-    )
-    .random.normal(
-        mean="custom_mean",
-        std="custom_std",
-        name="normal_str",
-    )
+    # Scalar parameters
+    .random.rand(low=1_000., high=2_000., seed=42, name="rand_scalar")
+    # Default range [0, 1)
+    .random.rand(seed=42, name="rand_default")
+    # Per-row parameters via expression
+    .random.rand(low=pl.col("custom_low"), high=pl.col("custom_high"), seed=42, name="rand_expr")
+    # Per-row parameters via column name
+    .random.rand(low="custom_low", high="custom_high", seed=42, name="rand_str")
 )
 ```
 
-### Binomial Distribution
+### `df.random.normal`
+
+| Parameter | Type                                    | Default    | Description                          |
+| --------- | --------------------------------------- | ---------- | ------------------------------------ |
+| `mean`    | `float`, `str`, `pl.Expr`, or `None`    | `0.0`      | Mean of the normal distribution.     |
+| `std`     | `float`, `str`, `pl.Expr`, or `None`    | `1.0`      | Standard deviation (must be `> 0`).  |
+| `seed`    | `int` or `None`                         | `None`     | Reproducible draws.                  |
+| `name`    | `str` or `None`                         | `"normal"` | Output column name.                  |
 
 ```python
 import polars as pl
 import polars_random
 
-df: pl.DataFrame = ...
+df = pl.DataFrame({
+    "custom_mean": [0.0, 5.0, -3.0],
+    "custom_std":  [1.0, 2.0, 0.5],
+})
 
-random_series = (
+(
     df
-    # Mandatory parameters n and p
-    .random.binomial(n=100, p=.5, seed=42, name="binomial")
-    .random.binomial(
-        n=pl.col("custom_n"),
-        p=pl.col("custom_p"),
-        name="binomial_expr",
-    )
-    .random.binomial(
-        n="n",
-        p="p",
-        name="binomial_str",
-    )
+    .random.normal(mean=3., std=2., seed=42, name="normal_scalar")
+    .random.normal(seed=42, name="normal_default")  # mean=0, std=1
+    .random.normal(mean=pl.col("custom_mean"), std=pl.col("custom_std"), seed=42, name="normal_expr")
+    .random.normal(mean="custom_mean", std="custom_std", seed=42, name="normal_str")
 )
 ```
+
+### `df.random.binomial`
+
+| Parameter | Type                          | Default      | Description                                         |
+| --------- | ----------------------------- | ------------ | --------------------------------------------------- |
+| `n`       | `int`, `str`, or `pl.Expr`    | *(required)* | Number of trials.                                   |
+| `p`       | `float`, `str`, or `pl.Expr`  | *(required)* | Probability of success on each trial (`0 ≤ p ≤ 1`). |
+| `seed`    | `int` or `None`               | `None`       | Reproducible draws.                                 |
+| `name`    | `str` or `None`               | `"binomial"` | Output column name.                                 |
+
+```python
+import polars as pl
+import polars_random
+
+df = pl.DataFrame({
+    "n": [10, 50, 100],
+    "p": [0.1, 0.5, 0.9],
+})
+
+(
+    df
+    .random.binomial(n=100, p=.5, seed=42, name="binomial_scalar")
+    .random.binomial(n=pl.col("n"), p=pl.col("p"), seed=42, name="binomial_expr")
+    .random.binomial(n="n", p="p", seed=42, name="binomial_str")
+)
+```
+
+## API reference
+
+See the [API Reference](api_reference.md) for the full signatures and docstrings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-random"
-description = "Polars plugin for generating random distributions"
+description = "Generate random numbers and statistical distributions natively in Polars DataFrames"
 authors = [
   { name = "Diego Garcia Lozano", email = "diegoglozano96@gmail.com" },
 ]
@@ -15,6 +15,46 @@ requires-python = ">=3.9"
 dependencies = [
     "polars>=1.0.0",
 ]
+keywords = [
+    "polars",
+    "polars-plugin",
+    "random",
+    "random-numbers",
+    "random-distribution",
+    "statistics",
+    "dataframe",
+    "uniform",
+    "normal",
+    "binomial",
+    "numpy",
+    "rust",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://diegoglozano.github.io/polars-random/"
+Documentation = "https://diegoglozano.github.io/polars-random/"
+Repository = "https://github.com/diegoglozano/polars-random"
+Issues = "https://github.com/diegoglozano/polars-random/issues"
+Changelog = "https://github.com/diegoglozano/polars-random/releases"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
- Correct stated default parameters for `rand` (`low=0.` / `high=1.`)
- Close unbalanced parens in the seeded `rand` snippet
- Replace nonexistent `mean`/`std` args in the uniform example with `low`/`high`
- Document `random.uniform` as an alias for `random.rand`
- Normalize spacing between installation code blocks