### PR TITLE
[release] bump version 0.3.2 -> 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "polars-random"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "polars",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-random"
-version = "0.3.2"
+version = "0.4.0"
 description = "Polars plugin for generating random distributions"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Tracks the release of the work landed in #21.

## Why 0.4.0 (minor, not patch)

- **New API surface** — `Expr` and `LazyFrame` namespaces, top-level helpers (`polars_random.rand/normal/binomial/randint(..., size=N)`)
- **New distribution** — `randint`
- **Behavior change (positive)** — column-valued parameters with nulls now propagate null instead of panicking

No breaking changes; the existing `df.random.<dist>(...)` API is unchanged.

## What's in this PR

Just the version bump + lockfile refresh:

- `Cargo.toml`: `0.3.2` -> `0.4.0`
- `Cargo.lock`: regenerated by `cargo update -p polars-random`

`tests/test_version.py` enforces that `__version__` (compiled from `Cargo.toml` via `env!("CARGO_PKG_VERSION")`) matches `Cargo.toml` itself, so this single edit is enough — the wheel maturin produces is labelled `0.4.0`.

## Test plan

- [x] `uv run maturin develop` rebuilds at `0.4.0`
- [x] `uv run pytest` — 29/29 passing, including `test_versions_match`

## After merge

1. Open the draft GitHub Release that release-drafter has been maintaining.
2. Edit the tag to **`v0.4.0`** (release-drafter may have auto-picked a different bump based on PR labels).
3. Click **Publish release** — that triggers `pypi_publish.yml`, which builds wheels (Linux x5, Windows x2, macOS x2, sdist) and uploads via PyPI trusted publishing.

https://claude.ai/code/session_01ALFPcsW4K8QVJfpoMgUznG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALFPcsW4K8QVJfpoMgUznG)_