### PR TITLE
fix(deps): bump ethnum 1.5.0 → 1.5.3 to fix build on newer Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fallible-streaming-iterator"


### PR DESCRIPTION
## Problem

CI on `main` is failing across the entire test matrix, `python-linting`, and `Clippy` (20/21 jobs). Every job that compiles the Rust extension dies on the same transitive-dependency error:

```
error[E0512]: cannot transmute between types of different sizes
  --> ethnum-1.5.0/src/error.rs:16:  unsafe { mem::transmute(()) }
     source type: `()` (0 bits) → target type: `TryFromIntError` (8 bits)
```

`ethnum 1.5.0` (pulled in transitively via `polars`) contains an unsound `mem::transmute(())` into `TryFromIntError`. Recent stable Rust made `TryFromIntError` non-zero-sized, so the transmute is now a hard error. The runners install a fresh `stable` toolchain each run, so this is a time-triggered breakage rather than anything in our code — any push to `main` fails identically.

## Fix

Bump `ethnum` to `1.5.3` (semver-compatible patch that fixes the transmute). It's a transitive dependency, so **only `Cargo.lock` changes** — no source edits.

## Verification (local, Rust 1.94.1)

- `cargo build -p ethnum` → compiles clean
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets` → passes (mirrors the CI Clippy job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xvVHohoDnX5n2wjXF3zX4

---
_Generated by [Claude Code](https://claude.ai/code/session_018xvVHohoDnX5n2wjXF3zX4)_