### PR TITLE
build(deps): bump psm 0.1.24 → 0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Applies the transitive dependency bump proposed in #17, on top of current `main` (so it picks up the recent ethnum build fix and stays green).

`psm` is a low-level stack-manipulation crate pulled in via `polars`; **only `Cargo.lock` changes** — no source or manifest edits, and the `polars-random` version stays at 0.4.0.

Supersedes #17, which was based on stale `main` and could not merge.

## Verification (local, Rust 1.94.1)
- `cargo build -p psm` → compiles clean
- `RUSTFLAGS="-D warnings" cargo build` (full tree) → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xvVHohoDnX5n2wjXF3zX4

---
_Generated by [Claude Code](https://claude.ai/code/session_018xvVHohoDnX5n2wjXF3zX4)_