### PR TITLE
Remove non-existent labels from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    labels:
+    - dependencies
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
+    labels:
+    - dependencies
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
+    labels:
+    - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    labels:
-    - skip-changelog
-    - dependencies
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
-    labels:
-    - skip-changelog
-    - dependencies
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
-    labels:
-    - skip-changelog
-    - dependencies


### PR DESCRIPTION
The 'dependencies' and 'skip-changelog' labels referenced in
dependabot.yml do not exist in the repository, causing Dependabot to
fail when trying to apply them. Remove the labels config so Dependabot
can open pull requests without error.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015vZmbPNcrR9bpgxJpacBcr