### PR TITLE
Bump rand_distr to 0.6 and rand to 0.10 to fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +296,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -560,6 +580,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1135,7 +1156,7 @@ dependencies = [
  "polars-schema",
  "polars-utils",
  "rand 0.9.5",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rayon",
  "regex",
  "serde",
@@ -1327,8 +1348,8 @@ dependencies = [
  "polars",
  "pyo3",
  "pyo3-polars",
- "rand 0.9.5",
- "rand_distr",
+ "rand 0.10.2",
+ "rand_distr 0.6.0",
  "serde",
 ]
 
@@ -1612,6 +1633,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1682,16 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1862,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ crate-type = ["cdylib"]
 polars = { version = "0.53.0", default-features = false }
 pyo3 = { version = "0.27", features = ["extension-module", "abi3-py39"] }
 pyo3-polars = { version = "0.26.0", features = ["derive"] }
-rand = { version = "0.9", features = ["small_rng"] }
-rand_distr = "0.5"
+rand = { version = "0.10" }
+rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -41,7 +41,7 @@ struct SeedArgs {
 fn make_rng(seed: Option<u64>) -> SmallRng {
     match seed {
         Some(i) => SmallRng::seed_from_u64(i),
-        None => SmallRng::from_os_rng(),
+        None => rand::make_rng(),
     }
 }
 


### PR DESCRIPTION
rand_distr 0.6.0 requires rand 0.10, so keeping rand at 0.9 left
SmallRng unable to satisfy the rand 0.10 Rng bound in
Distribution::sample, breaking the build across all CI jobs.

- Bump rand to 0.10 (small_rng feature was removed; SmallRng is now
  always available)
- Replace removed SmallRng::from_os_rng() with rand::make_rng()

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Qj7k4BkjBFGwHibt3iCDG