### PR TITLE
feat: add global seed via pr.set_random_seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Available distributions: `rand` / `uniform`, `normal`, `binomial`, `randint`. Ev
 
 - **Polars-native** — outputs are regular Polars columns, composable with the rest of your pipeline (no NumPy round-trips).
 - **Per-row parameters** — `mean`, `std`, `low`, `high`, `n`, `p` can come from other columns, so each row can be drawn from a different distribution.
-- **Reproducible** — pass `seed=...` for deterministic draws.
+- **Reproducible** — pass `seed=...` per call, or set one global seed with `pr.set_random_seed(...)`.
 - **Fast** — implemented in Rust on top of `rand` / `rand_distr`.
 
 ## Installation
@@ -85,10 +85,46 @@ df.random.<distribution>(<params>, seed=None, name=None)
 | `np.random.normal(mean, std, size=n)`    | `pr.normal(mean=mean, std=std, size=n)`                             |
 | `np.random.binomial(n, p, size=size)`    | `pr.binomial(n=n, p=p, size=size)`                                  |
 | `np.random.randint(low, high, size=n)`   | `pr.randint(low=low, high=high, size=n)`                            |
-| `np.random.seed(42)` (global)            | `seed=42` per call                                                  |
+| `np.random.seed(42)` (global)            | `pr.set_random_seed(42)` (global) &nbsp;or&nbsp; `seed=42` per call  |
 | Different params per row (loop / vectorize manually) | Pass a column name or `pl.col(...)` as the parameter      |
 
 When used as a DataFrame/LazyFrame method or via the `pl.col(...).random` namespace, the output length is taken from the parent — no `size=` needed. Use `size=N` only with the top-level functions for "give me N values without a frame."
+
+## Seeding & reproducibility
+
+Every draw takes an optional `seed=`. There are two ways to make results reproducible:
+
+**Per call** — pass `seed=` to a single expression:
+
+```python
+pr.normal(mean=0.0, std=1.0, seed=42)
+```
+
+**Globally** — set one seed once with `pr.set_random_seed(...)`. Any draw that omits `seed=` then derives its seed from this global generator:
+
+```python
+import polars as pl
+import polars_random as pr
+
+pr.set_random_seed(42)
+
+df = pl.DataFrame({"id": range(5)})
+df.with_columns(
+    a=pr.normal(),               # reproducible — no per-call seed needed
+    b=pr.rand(),                 # independent of `a`, also reproducible
+)
+```
+
+This solves the "keep the distribution definition separate from where I set the seed" workflow: define length-free expressions (`pr.normal(3.0, 1.0)`) and let one global seed make the whole run reproducible, without threading `seed=42` through every call.
+
+Semantics:
+
+- **Each expression consumes the global generator once**, so distinct random columns in the same query stay independent (they are *not* byte-for-byte identical), just like NumPy's global RNG or `polars`' own `set_random_seed`.
+- **Re-calling `pr.set_random_seed(42)`** rewinds the sequence, so a script re-run reproduces the same draws.
+- **An explicit `seed=`** on a call always overrides the global seed for that call.
+- **Without any global seed**, seedless draws use OS entropy (the historical default) — nothing changes for existing code.
+
+> `pr.set_random_seed` is independent of `polars.set_random_seed`. Polars seeds its *own* operations (`.sample()`, `.shuffle()`, …) and exposes only a setter — there is no public way for a plugin to read Polars' seed — so `polars-random` keeps its own global seed. Set both if you want Polars *and* `polars-random` reproducible in the same script.
 
 ## Distributions
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ Semantics:
 - **An explicit `seed=`** on a call always overrides the global seed for that call.
 - **Without any global seed**, seedless draws use OS entropy (the historical default) — nothing changes for existing code.
 
+### Want two *identical* columns?
+
+Seedless draws under a global seed are always independent (that is the point), so they never coincide. To make two columns equal, give them the **same explicit `seed=`** — that pins both to the same draw and bypasses the global generator:
+
+```python
+df.with_columns(
+    a=pr.normal(seed=7),
+    b=pr.normal(seed=7),   # a == b, byte-for-byte
+)
+```
+
+### Reproducibility depends on call order
+
+Under a global seed, each seedless draw takes the *next* value from the generator, so reproducibility depends on the **order and number** of seedless draws — the same sequence of calls reproduces the same columns. Inserting or reordering a seedless draw shifts every later one (exactly like NumPy's or Polars' global RNG). If a specific column must stay fixed regardless of surrounding code, pin it with an explicit `seed=`.
+
 > `pr.set_random_seed` is independent of `polars.set_random_seed`. Polars seeds its *own* operations (`.sample()`, `.shuffle()`, …) and exposes only a setter — there is no public way for a plugin to read Polars' seed — so `polars-random` keeps its own global seed. Set both if you want Polars *and* `polars-random` reproducible in the same script.
 
 ## Distributions

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -37,6 +37,15 @@ df = pl.DataFrame({"id": range(5)})
 df.with_columns(a=pr.normal(), b=pr.rand())  # reproducible, no per-call seed
 ```
 
+Reproducibility depends on the order and number of seedless draws (each takes
+the next value from the generator, like NumPy's or Polars' global RNG). To make
+two columns *identical*, give them the same explicit `seed=` — the global seed
+is designed to keep seedless draws independent:
+
+```python
+df.with_columns(a=pr.normal(seed=7), b=pr.normal(seed=7))  # a == b
+```
+
 `pr.set_random_seed` is independent of `polars.set_random_seed` (which seeds
 Polars' own `.sample()` / `.shuffle()` and is not readable by plugins).
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -21,6 +21,28 @@ Returns a `pl.Expr` by default, or a `pl.Series` of length `size` when `size=` i
 ::: polars_random.randint
     handler: python
 
+## Global seed
+
+Set one seed for the whole session. Any draw that omits `seed=` then derives its
+seed from this global generator; an explicit `seed=` on a call still overrides it.
+Distinct expressions consume the generator separately, so they stay independent
+while remaining reproducible across re-runs.
+
+```python
+import polars as pl
+import polars_random as pr
+
+pr.set_random_seed(42)
+df = pl.DataFrame({"id": range(5)})
+df.with_columns(a=pr.normal(), b=pr.rand())  # reproducible, no per-call seed
+```
+
+`pr.set_random_seed` is independent of `polars.set_random_seed` (which seeds
+Polars' own `.sample()` / `.shuffle()` and is not readable by plugins).
+
+::: polars_random.set_random_seed
+    handler: python
+
 ## `pl.col(...).random` — expression namespace
 
 Use inside any expression context (`select`, `with_columns`, lazy queries, group-by aggregations, …). The parent expression provides the row count.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Available distributions: `rand` / `uniform`, `normal`, `binomial`, `randint`. Ev
 
 - **Polars-native** — outputs are regular Polars columns, composable with the rest of your pipeline (no NumPy round-trips).
 - **Per-row parameters** — `mean`, `std`, `low`, `high`, `n`, `p` can come from other columns, so each row can be drawn from a different distribution.
-- **Reproducible** — pass `seed=...` for deterministic draws.
+- **Reproducible** — pass `seed=...` per call, or set one global seed with `pr.set_random_seed(...)`.
 - **Fast** — implemented in Rust on top of `rand` / `rand_distr`.
 
 ## Installation
@@ -74,7 +74,7 @@ Every distribution is a single underlying Rust kernel exposed in four ways:
 | `df.random.<dist>(...)` / `lf.random.<dist>(...)` | `pl.DataFrame` / `pl.LazyFrame` (column appended) |
 
 - Each parameter accepts **a Python literal**, **a column name as a string**, or **a Polars expression** (`pl.col(...)`, arithmetic, etc.). Within a single call, the distribution's parameters must be the same kind — either all literals or all expressions/column-names (no mixing).
-- `seed` makes the draw reproducible. Omit it for entropy-based randomness.
+- `seed` makes the draw reproducible. Omit it for entropy-based randomness, or set one global seed for the whole session with `pr.set_random_seed(...)` (see [Global seed](api_reference.md#global-seed)).
 - For DataFrame/LazyFrame methods, `name` is the new column's name. Defaults to the distribution name (`"rand"`, `"normal"`, `"binomial"`, `"randint"`).
 - Nulls in column-valued parameters become null in the output.
 
@@ -86,7 +86,7 @@ Every distribution is a single underlying Rust kernel exposed in four ways:
 | `np.random.normal(mean, std, size=n)`    | `pr.normal(mean=mean, std=std, size=n)`                             |
 | `np.random.binomial(n, p, size=size)`    | `pr.binomial(n=n, p=p, size=size)`                                  |
 | `np.random.randint(low, high, size=n)`   | `pr.randint(low=low, high=high, size=n)`                            |
-| `np.random.seed(42)` (global)            | `seed=42` per call                                                  |
+| `np.random.seed(42)` (global)            | `pr.set_random_seed(42)` (global) &nbsp;or&nbsp; `seed=42` per call  |
 | Different params per row (loop / vectorize manually) | Pass a column name or `pl.col(...)` as the parameter      |
 
 When used as a DataFrame/LazyFrame method or via the `pl.col(...).random` namespace, the output length is taken from the parent — no `size=` needed. Use `size=N` only with the top-level functions for "give me N values without a frame."

--- a/polars_random/__init__.py
+++ b/polars_random/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random as _random
 from pathlib import Path
 from typing import Union
 
@@ -13,6 +14,7 @@ __all__ = [
     "normal",
     "rand",
     "randint",
+    "set_random_seed",
     "uniform",
 ]
 
@@ -20,6 +22,70 @@ LIB = Path(__file__).parent
 
 FloatParam = Union[float, int, pl.Expr, str, None]
 IntParam = Union[int, pl.Expr, str, None]
+
+# Module-global generator used to derive per-expression seeds when the caller
+# does not pass an explicit ``seed=``. ``None`` means "no global seed set", in
+# which case draws fall back to OS entropy (the historical default).
+_GLOBAL_RNG: _random.Random | None = None
+# Width of the derived seeds fed to the Rust kernel. 63 bits keeps the value
+# inside both u64 and i64 ranges (robust to kwargs serialization) while leaving
+# ample seed entropy.
+_SEED_BITS = 63
+
+
+def set_random_seed(seed: int) -> None:
+    """
+    Set a global default seed for all ``polars-random`` draws.
+
+    Once set, any ``polars-random`` expression that does **not** pass an
+    explicit ``seed=`` derives its seed from this global generator. Each
+    expression consumes the generator, so distinct random columns in the same
+    query stay independent (not byte-for-byte identical) while the whole run
+    remains reproducible. Re-calling ``set_random_seed`` with the same value
+    rewinds the sequence, reproducing the same draws.
+
+    An explicit ``seed=`` on an individual call always overrides the global
+    seed for that call.
+
+    This is independent of :func:`polars.set_random_seed`, which seeds Polars'
+    own operations (``.sample()``, ``.shuffle()``, …) and is not readable by
+    third-party plugins.
+
+    Parameters
+    ----------
+    seed : int
+        A non-negative integer used to seed the internal global generator.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> import polars_random as pr
+    >>> pr.set_random_seed(42)
+    >>> df = pl.DataFrame({"id": range(3)})
+    >>> a = df.with_columns(x=pr.normal())  # reproducible without seed=
+    >>> pr.set_random_seed(42)
+    >>> b = df.with_columns(x=pr.normal())
+    >>> a.equals(b)
+    True
+    """
+    if seed is None or seed < 0:
+        raise ValueError("Seed must be a non-negative integer")
+    global _GLOBAL_RNG
+    _GLOBAL_RNG = _random.Random(seed)
+
+
+def _resolve_seed(seed: int | None) -> int | None:
+    """Return the effective seed for a single draw.
+
+    An explicit ``seed`` wins. Otherwise, if a global seed has been set, draw
+    the next seed from the global generator (advancing it). If no global seed
+    is set, return ``None`` so the kernel uses OS entropy.
+    """
+    if seed is not None:
+        return seed
+    if _GLOBAL_RNG is None:
+        return None
+    return _GLOBAL_RNG.getrandbits(_SEED_BITS)
 
 
 def _check_seed(seed: int | None) -> None:
@@ -66,6 +132,7 @@ def _rand_expr(
 ) -> pl.Expr:
     _check_seed(seed)
     _consistent_pair(low, high, ("low", "high"))
+    seed = _resolve_seed(seed)
 
     if _is_columnar(low):
         return register_plugin_function(
@@ -92,6 +159,7 @@ def _normal_expr(
 ) -> pl.Expr:
     _check_seed(seed)
     _consistent_pair(mean, std, ("mean", "std"))
+    seed = _resolve_seed(seed)
 
     if _is_columnar(mean):
         return register_plugin_function(
@@ -120,6 +188,7 @@ def _binomial_expr(
     _consistent_pair(n, p, ("n", "p"))
     if isinstance(p, (int, float)):
         _check_probability(float(p))
+    seed = _resolve_seed(seed)
 
     if _is_columnar(n):
         return register_plugin_function(
@@ -146,6 +215,7 @@ def _randint_expr(
 ) -> pl.Expr:
     _check_seed(seed)
     _consistent_pair(low, high, ("low", "high"))
+    seed = _resolve_seed(seed)
 
     if _is_columnar(low):
         return register_plugin_function(

--- a/polars_random/__init__.py
+++ b/polars_random/__init__.py
@@ -45,7 +45,11 @@ def set_random_seed(seed: int) -> None:
     rewinds the sequence, reproducing the same draws.
 
     An explicit ``seed=`` on an individual call always overrides the global
-    seed for that call.
+    seed for that call. Because each seedless draw takes the *next* value from
+    the generator, reproducibility depends on the order and number of seedless
+    draws: inserting or reordering one shifts every later draw. To make two
+    columns *identical*, give them the same explicit ``seed=`` rather than
+    relying on the global seed (which is designed to keep them independent).
 
     This is independent of :func:`polars.set_random_seed`, which seeds Polars'
     own operations (``.sample()``, ``.shuffle()``, …) and is not readable by

--- a/tests/test_polars_random.py
+++ b/tests/test_polars_random.py
@@ -3,6 +3,15 @@ import pytest
 
 import polars_random as pr  # noqa: F401  (also registers namespaces)
 
+
+@pytest.fixture(autouse=True)
+def _reset_global_seed():
+    """Keep the module-global seed from leaking between tests."""
+    pr._GLOBAL_RNG = None
+    yield
+    pr._GLOBAL_RNG = None
+
+
 # ---------------- DataFrame namespace (existing) ----------------
 
 
@@ -194,3 +203,70 @@ def test_per_row_normal_via_expr():
     df = pl.DataFrame({"m": [0.0] * 10, "s": [1.0] * 10})
     out = df.with_columns(n=pl.col("m").random.normal(mean=pl.col("m"), std=pl.col("s"), seed=42))
     assert out["n"].len() == 10
+
+
+# ---------------- Global seed (new) ----------------
+
+
+def test_global_seed_makes_seedless_reproducible():
+    df = pl.DataFrame({"x": range(100)})
+    pr.set_random_seed(42)
+    a = df.with_columns(r=pr.normal()).get_column("r").to_list()
+    pr.set_random_seed(42)
+    b = df.with_columns(r=pr.normal()).get_column("r").to_list()
+    assert a == b
+
+
+def test_global_seed_distinct_expressions_are_independent():
+    # Two seedless draws in the same query consume the global generator
+    # separately, so they must not be byte-for-byte identical.
+    df = pl.DataFrame({"x": range(1_000)})
+    pr.set_random_seed(42)
+    out = df.with_columns(a=pr.normal(), b=pr.normal())
+    assert out["a"].to_list() != out["b"].to_list()
+
+
+def test_explicit_seed_overrides_global():
+    df = pl.DataFrame({"x": range(100)})
+    pr.set_random_seed(42)
+    with_global = df.with_columns(r=pr.rand()).get_column("r").to_list()
+    explicit = df.with_columns(r=pr.rand(seed=123)).get_column("r").to_list()
+    reference = df.with_columns(r=pr.rand(seed=123)).get_column("r").to_list()
+    assert explicit == reference
+    assert explicit != with_global
+
+
+def test_global_seed_applies_across_entry_points():
+    # Top-level size=, expr namespace, df namespace and lazy all honor it.
+    pr.set_random_seed(7)
+    top = pr.rand(size=50).to_list()
+    pr.set_random_seed(7)
+    expr = (
+        pl.DataFrame({"x": range(50)})
+        .with_columns(r=pl.col("x").random.rand())
+        .get_column("r")
+        .to_list()
+    )
+    pr.set_random_seed(7)
+    lazy = (
+        pl.DataFrame({"x": range(50)})
+        .lazy()
+        .random.rand(name="r")
+        .collect()
+        .get_column("r")
+        .to_list()
+    )
+    assert top == expr == lazy
+
+
+def test_set_random_seed_negative_raises():
+    with pytest.raises(ValueError, match="non-negative"):
+        pr.set_random_seed(-1)
+
+
+def test_no_global_seed_leaves_entropy_default():
+    # Without a global seed, seedless draws stay entropy-based (independent).
+    df = pl.DataFrame({"x": range(1_000)})
+    a = df.with_columns(r=pr.rand()).get_column("r").to_list()
+    b = df.with_columns(r=pr.rand()).get_column("r").to_list()
+    assert a != b

--- a/tests/test_polars_random.py
+++ b/tests/test_polars_random.py
@@ -226,6 +226,15 @@ def test_global_seed_distinct_expressions_are_independent():
     assert out["a"].to_list() != out["b"].to_list()
 
 
+def test_same_explicit_seed_gives_identical_columns():
+    # Documented recipe for two equal columns: same explicit seed, which
+    # bypasses the (independence-preserving) global generator.
+    df = pl.DataFrame({"x": range(100)})
+    pr.set_random_seed(42)
+    out = df.with_columns(a=pr.normal(seed=7), b=pr.normal(seed=7))
+    assert out["a"].to_list() == out["b"].to_list()
+
+
 def test_explicit_seed_overrides_global():
     df = pl.DataFrame({"x": range(100)})
     pr.set_random_seed(42)


### PR DESCRIPTION
Closes #27.

## Motivation

The issue asks for a global seed so a distribution can be defined without a fixed size/seed and still be reproducible, without threading `seed=42` through every call.

Polars' own `polars.set_random_seed` seeds only Polars' internal operations (`.sample()`, `.shuffle()`, …), exposes **no getter**, and lives in a separate compiled runtime — so a plugin cannot read or reuse it. This PR gives `polars-random` its own global seed instead.

## What changed

- **`pr.set_random_seed(seed)`** seeds a stateful module-global generator.
- Any draw that omits `seed=` derives its seed from this generator, so **distinct random columns in one query stay independent** (not byte-for-byte identical), matching NumPy's / Polars' own global-RNG semantics. Re-seeding rewinds the sequence, so a re-run reproduces the same draws.
- An explicit `seed=` on a call still **overrides** the global seed for that call.
- With **no global seed set**, seedless draws remain entropy-based — existing behavior is unchanged.

## Design note

The default seed is resolved in **Python at expression-build time**, not in a Rust global read at execution. This means:

- **No Rust kernel changes** (the kernels already accept a concrete seed).
- **No cross-thread race** under the streaming engine — a Rust `static` RNG would have produced non-deterministic results across parallel chunks.

It applies uniformly across all four entry points (top-level `size=`, `pl.col(...).random`, `df.random`, `lf.random`) since they all funnel through the same builders.

One behavioral consequence: because the default seed is fixed at build time, reusing the *same* expression object in several contexts shares its one drawn seed; rebuilding the expression (or calling under a fresh `set_random_seed`) yields independent draws.

## Tests & docs

- 7 new tests: reproducibility, per-expression independence, explicit-seed override, cross-entry-point behavior, negative-seed validation, and the entropy-default fallback (plus an autouse fixture resetting global state between tests).
- `README.md` — new "Seeding & reproducibility" section + updated NumPy-comparison row.
- `docs/index.md` / `docs/api_reference.md` — global-seed section and API entry, noting independence from `polars.set_random_seed`.

## Verification

- `maturin develop` build succeeds; **35 tests pass**.
- `ruff check`, `ruff format --check`, and `ty` are clean. Rust is untouched, so clippy/fmt/check are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk)_