### PR TITLE
fix(ci): make release-drafter category labels arrays

### DIFF
--- a/.github/release_drafter_template.yml
+++ b/.github/release_drafter_template.yml
@@ -15,9 +15,11 @@ categories:
   - title: '⚠ Breaking changes'
     label: 'breaking-change'
   - title: 'Features'
-    labels: 'enhancement'
+    labels:
+      - 'enhancement'
   - title: 'Bug Fixes'
-    labels: 'bug'
+    labels:
+      - 'bug'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes


### PR DESCRIPTION
## Problem

The **Release Drafter** workflow fails on every push to `main`. Root cause is two things combining:

1. A Dependabot bump moved the action from `release-drafter@v6` → `@v7`. The last green run was on v6 (PR #35); every run since (#36 onward) fails.
2. `@v7` tightened config-schema validation and now rejects a bare **string** for the plural `labels` key. The failing runs error with:

   ```
   categories[1].labels: expected "array" (invalid_type)
   categories[2].labels: expected "array"
   ```

In `.github/release_drafter_template.yml`, the `Features` and `Bug Fixes` categories set `labels:` to a string. v6 tolerated it; v7 requires a list. (`Breaking changes` is fine — it uses the singular `label`, which still accepts a string.)

## Fix

Wrap those two category labels in lists:

```yaml
  - title: 'Features'
    labels:
      - 'enhancement'
  - title: 'Bug Fixes'
    labels:
      - 'bug'
```

## Backfill

None needed. Release Drafter rebuilds the **entire** draft from scratch on each run (all merged PRs since the last published release), so merging this PR is itself a push to `main` that triggers a green run and regenerates the draft — automatically including everything merged while it was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk)_