### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "polars-random"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "polars",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-random"
-version = "0.4.0"
+version = "0.5.0"
 description = "Polars plugin for generating random distributions"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Bumps the version from `0.4.0` → `0.5.0` in preparation for a release.

## Why

The Python package version is **dynamic** (`pyproject.toml` → `dynamic = ["version"]`), so maturin derives it from `Cargo.toml`'s `[package] version`. That value is what gets published to PyPI when a GitHub release is published (`pypi_publish.yml` runs on `release: published`). Bumping it here is the required step before cutting a release — without it, the build would rebuild `0.4.0` and the `--skip-existing` upload would silently no-op.

Minor bump because the release adds the `pr.set_random_seed` global-seed feature (#42), which is backward-compatible.

## Changes

- `Cargo.toml`: `version = "0.5.0"`
- `Cargo.lock`: matching `polars-random` entry

## Verification

Rebuilt the extension (`maturin develop`) and ran `tests/test_version.py` — `test_versions_match` passes, confirming `polars_random.__version__ == "0.5.0"` matches `Cargo.toml`.

## Release steps after merge

1. Merge #43 first (fixes Release Drafter) so the draft regenerates with the real changelog.
2. Merge this PR.
3. Publish the Release Drafter draft release with tag `v0.5.0` → triggers `pypi_publish.yml` → publishes `0.5.0` to PyPI via trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWEmdDPGNLofqNtBxDNAwk)_